### PR TITLE
Added line break handling for Claude & ChatGPT in inputBoxHandler.js

### DIFF
--- a/inputBoxHandler.js
+++ b/inputBoxHandler.js
@@ -101,8 +101,26 @@ class InputBoxHandler {
         if (inputBox.contentEditable === 'true') {
           // For contenteditable elements (e.g., ChatGPT and Claude)
           inputBox.innerHTML = '';
-          const textNode = document.createTextNode(content + '  '); // Add two spaces
-          inputBox.appendChild(textNode);
+          // Line break handling for CodeMirror 
+          // Split content by line breaks and create elements for each line
+          const lines = content.split('\n');
+          lines.forEach((line, index) => {
+            if (line.trim()) {
+              // If line has text content, wrap it in a paragraph
+              const p = document.createElement('p');
+              p.textContent = line;
+              inputBox.appendChild(p);
+            } else if (index < lines.length - 1) {
+              // If line is empty (and not the last line), add p-wrapped-br
+              const p = document.createElement('p');
+              const br = document.createElement('br');
+              p.appendChild(br);
+              inputBox.appendChild(p);
+            }
+          });
+          
+          // Add two spaces at the end
+          inputBox.appendChild(document.createTextNode('  '));
   
           // Move cursor to the end of the content
           const range = document.createRange();


### PR DESCRIPTION
As both Claude and ChatGPT use [CodeMirror ](https://codemirror.net/) insead of TextArea the normal line breaks '/n' don't work there. CodeMirror uses paragraphs for text blocks and breaks wrapped in paragraphs for stand alone line breaks.

Testing the change with a simple prompt consiting of text lines separated by breaks and an empty line with a break:

![image](https://github.com/user-attachments/assets/d7c21de4-4c2b-4ffb-a7e9-c82180ba1fed)

Result in ChatGPT:
![image](https://github.com/user-attachments/assets/a85cb1f7-d730-406a-8b66-a0e08139cbda)

And Claude:
![image](https://github.com/user-attachments/assets/2ba73fb7-086d-4220-a91f-052a6f14d3ba)

