### PR TITLE
Fix Perplexity multiline prompt insertion

### DIFF
--- a/src/inputBoxHandler.js
+++ b/src/inputBoxHandler.js
@@ -122,15 +122,44 @@ class InputBoxHandler {
             document.execCommand('delete', false, null);
           }
 
-          // COMMENT: Primary path — let the editor handle text via execCommand
+          // COMMENT: Multiline prompts need a paste-style event in Lexical editors.
+          // COMMENT: insertText can flatten newlines in Perplexity's editor.
           const textToInsert = content + '  ';
-          const inserted = document.execCommand('insertText', false, textToInsert);
+          const getPlainEditorText = () => inputBox.innerText || inputBox.textContent || '';
+          const beforeInsertionText = getPlainEditorText();
+          let inserted = false;
+
+          if (content.includes('\n')) {
+            try {
+              const dataTransfer = new DataTransfer();
+              dataTransfer.setData('text/plain', textToInsert);
+              const pasteEvent = new ClipboardEvent('paste', {
+                clipboardData: dataTransfer,
+                bubbles: true,
+                cancelable: true,
+              });
+              inputBox.dispatchEvent(pasteEvent);
+              const afterPasteText = getPlainEditorText();
+              inserted = afterPasteText.length > beforeInsertionText.length;
+            } catch (_) {
+              inserted = false;
+            }
+          }
+
+          // COMMENT: Primary single-line path, and fallback when synthetic paste is ignored.
+          if (!inserted) {
+            try {
+              inserted = document.execCommand('insertText', false, textToInsert);
+            } catch (_) {
+              inserted = false;
+            }
+          }
 
           // COMMENT: Fallback — synthesize input pipeline events
           if (!inserted) {
             try {
               inputBox.dispatchEvent(new InputEvent('beforeinput', {
-                inputType: 'insertText',
+                inputType: content.includes('\n') ? 'insertFromPaste' : 'insertText',
                 data: textToInsert,
                 bubbles: true,
                 cancelable: true,


### PR DESCRIPTION
## Summary

Fixes #72.

This updates the Lexical editor insertion path used by Perplexity so multiline prompts are inserted through a paste-style event before falling back to `execCommand('insertText')`.

## Why

Perplexity's `#ask-input` is handled as a Lexical editor. The current path uses `insertText`, which can flatten newlines and turn multiline prompts into one long paragraph.

## Changes

- Detect multiline prompt content in the Lexical editor path.
- Dispatch a synthetic `paste` event with `text/plain` content for multiline prompts.
- Keep the existing `insertText` behavior as the fallback and primary single-line path.
- Preserve the existing append/overwrite preference behavior.

## Testing

Not run locally from this connector.

Manual test recommended:

1. Install/load the extension branch.
2. Open Perplexity.
3. Insert the multiline prompt from issue #72.
4. Confirm bullets and blank lines are preserved in the input box.
5. Repeat once with append mode enabled to confirm existing text is not replaced.