### PR TITLE
Fix prompt manager posting prompts twice on ChatGPT and Perplexity

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -69,6 +69,18 @@ export default [
     rules: classicScriptRules,
   },
   {
+    files: ['src/utils/promptInsertUtils.js'],
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        module: 'writable',
+      },
+      ecmaVersion: 2022,
+      sourceType: 'script',
+    },
+    rules: classicScriptRules,
+  },
+  {
     files: ['src/content.styles.js', 'src/handlers/inputBoxHandler.js'],
     languageOptions: {
       globals: {
@@ -76,6 +88,7 @@ export default [
         ...globals.webextensions,
         chrome: 'readonly',
         PromptUIManager: 'readonly',
+        PromptInsertUtils: 'readonly',
       },
       ecmaVersion: 2022,
       sourceType: 'script',

--- a/src/content.js
+++ b/src/content.js
@@ -671,7 +671,10 @@ if (window.matchMedia) {
 /* [08] Simple Event Bus */
 class EventBus {
   constructor() { this.events = {}; }
-  on(evt, listener) { (this.events[evt] = this.events[evt] || []).push(listener); }
+  on(evt, listener) {
+    const list = (this.events[evt] = this.events[evt] || []);
+    if (!list.includes(listener)) list.push(listener);
+  }
   emit(evt, ...args) { (this.events[evt] || []).forEach(fn => fn(...args)); }
 }
 
@@ -2155,6 +2158,8 @@ const PromptMediator = (() => {
     mutationObserver: null,
     storageWatcherAttached: false,
     uiRecoverInProgress: false,
+    lastPromptSelectAt: 0,
+    lastPromptSelectKey: null,
   };
 
   /**
@@ -2162,6 +2167,15 @@ const PromptMediator = (() => {
    * @param {Prompt} prompt
    */
   const handlePromptSelect = async (prompt) => {
+    // COMMENT: Ignore duplicate click/keyboard fires that would insert the same prompt twice
+    const selectKey = prompt?.uuid || prompt?.content || '';
+    const now = Date.now();
+    if (selectKey && selectKey === state.lastPromptSelectKey && now - state.lastPromptSelectAt < 400) {
+      return;
+    }
+    state.lastPromptSelectKey = selectKey;
+    state.lastPromptSelectAt = now;
+
     // COMMENT: Be resilient — if input box isn't ready yet, wait briefly before giving up
     let inputBox = await window.InputBoxHandler.getInputBox();
     if (!inputBox) {

--- a/src/handlers/inputBoxHandler.js
+++ b/src/handlers/inputBoxHandler.js
@@ -324,76 +324,289 @@ class InputBoxHandler {
   }
 
   /**
-   * COMMENT: Shared execCommand insert path for rich-text editors (Lexical, Quill, ProseMirror).
+   * COMMENT: Read visible editor text across textarea and contenteditable inputs.
+   * @param {HTMLElement} inputBox
+   * @returns {string}
+   */
+  static _readPlainText(inputBox) {
+    if (!inputBox) return '';
+    const tag = inputBox.tagName?.toLowerCase();
+    if (tag === 'textarea' || tag === 'input') return inputBox.value || '';
+    return (inputBox.innerText || inputBox.textContent || '').replace(/\u00a0/g, ' ');
+  }
+
+  /**
+   * COMMENT: ChatGPT/Perplexity turn synthetic paste into a quote card or paste.txt.
+   * @returns {boolean}
+   */
+  static _avoidSyntheticPaste() {
+    const utils = (typeof PromptInsertUtils !== 'undefined' && PromptInsertUtils)
+      || (typeof window !== 'undefined' && window.PromptInsertUtils);
+    if (utils?.siteConvertsPasteToAttachment) {
+      return utils.siteConvertsPasteToAttachment(window.location.hostname);
+    }
+    return /(?:^|\.)chatgpt\.com$|(?:^|\.)chat\.openai\.com$|(?:^|\.)perplexity\.ai$/i
+      .test(window.location.hostname || '');
+  }
+
+  /**
+   * COMMENT: Prefer the nested Lexical/ProseMirror/Quill node when the selector hits a wrapper.
+   * @param {HTMLElement} inputBox
+   * @returns {HTMLElement}
+   */
+  static _resolveRichEditor(inputBox) {
+    if (!(inputBox instanceof HTMLElement)) return inputBox;
+    const nested = inputBox.querySelector?.(
+      '[data-lexical-editor="true"], .ProseMirror[contenteditable="true"], .ql-editor[contenteditable="true"]'
+    );
+    if (nested instanceof HTMLElement && nested !== inputBox) return nested;
+    return inputBox;
+  }
+
+  /**
+   * COMMENT: Detect rich editors, including nested nodes and ChatGPT/Perplexity hosts.
+   * @param {HTMLElement} inputBox
+   * @returns {boolean}
+   */
+  static _isRichEditor(inputBox) {
+    if (!(inputBox instanceof HTMLElement)) return false;
+    if (inputBox.id === 'ask-input' || inputBox.id === 'prompt-textarea') return true;
+    if (InputBoxHandler._avoidSyntheticPaste()) return true;
+    return Boolean(
+      inputBox.getAttribute('data-lexical-editor') === 'true'
+      || inputBox.classList.contains('ProseMirror')
+      || inputBox.classList.contains('ql-editor')
+      || inputBox.closest?.('[data-lexical-editor="true"], .ProseMirror, .ql-container, rich-textarea')
+      || inputBox.querySelector?.('[data-lexical-editor="true"], .ProseMirror, .ql-editor')
+    );
+  }
+
+  /**
+   * COMMENT: Place the caret in the editor. collapseToEnd keeps existing text for append mode.
+   * @param {HTMLElement} inputBox
+   * @param {boolean} collapseToEnd
+   */
+  static _focusAndSelect(inputBox, collapseToEnd) {
+    inputBox.focus();
+    const selection = window.getSelection();
+    if (!selection || typeof document.createRange !== 'function') return;
+    const range = document.createRange();
+    range.selectNodeContents(inputBox);
+    if (collapseToEnd) range.collapse(false);
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  /**
+   * COMMENT: True when the editor gained the inserted text.
+   * @param {string} before
+   * @param {string} after
+   * @param {string} inserted
+   * @returns {boolean}
+   */
+  static _textGained(before, after, inserted) {
+    if (!inserted) return after !== before;
+    if (after === before) return false;
+    const utils = (typeof PromptInsertUtils !== 'undefined' && PromptInsertUtils)
+      || (typeof window !== 'undefined' && window.PromptInsertUtils);
+    const haystack = utils?.normalizeEditorText ? utils.normalizeEditorText(after) : after.trim();
+    const needle = utils?.normalizeEditorText ? utils.normalizeEditorText(inserted) : inserted.trim();
+    return haystack.includes(needle) && after.length > before.length;
+  }
+
+  /**
+   * COMMENT: Insert once — beforeinput first so Lexical/ProseMirror can preventDefault, then execCommand.
+   * @param {HTMLElement} inputBox
+   * @param {string} text
+   * @returns {boolean}
+   */
+  static _insertTextOnce(inputBox, text) {
+    if (!text) return true;
+    const before = InputBoxHandler._readPlainText(inputBox);
+
+    try {
+      inputBox.dispatchEvent(new InputEvent('beforeinput', {
+        inputType: 'insertText',
+        data: text,
+        bubbles: true,
+        cancelable: true,
+      }));
+    } catch (_) {
+      // COMMENT: InputEvent may be rejected in older editor contexts
+    }
+
+    let after = InputBoxHandler._readPlainText(inputBox);
+    if (InputBoxHandler._textGained(before, after, text)) return true;
+
+    try {
+      if (document.execCommand('insertText', false, text)) {
+        after = InputBoxHandler._readPlainText(inputBox);
+        if (InputBoxHandler._textGained(before, after, text)) return true;
+      }
+    } catch (_) {
+      // COMMENT: execCommand may be unavailable in some editor contexts
+    }
+
+    return false;
+  }
+
+  /**
+   * COMMENT: Preserve newlines without a paste event (paste becomes a quote/attachment on some hosts).
+   * @param {HTMLElement} inputBox
+   * @returns {boolean}
+   */
+  static _insertLineBreak(inputBox) {
+    try {
+      if (document.execCommand('insertLineBreak', false, null)) return true;
+    } catch (_) {
+      // ignore
+    }
+    try {
+      if (document.execCommand('insertParagraph', false, null)) return true;
+    } catch (_) {
+      // ignore
+    }
+    try {
+      const before = InputBoxHandler._readPlainText(inputBox);
+      inputBox.dispatchEvent(new InputEvent('beforeinput', {
+        inputType: 'insertLineBreak',
+        bubbles: true,
+        cancelable: true,
+      }));
+      const after = InputBoxHandler._readPlainText(inputBox);
+      if (after !== before) return true;
+    } catch (_) {
+      // ignore
+    }
+    return InputBoxHandler._insertTextOnce(inputBox, '\n');
+  }
+
+  /**
+   * COMMENT: Last-resort paste. Never combine this with a second text write.
+   * @param {HTMLElement} inputBox
+   * @param {string} text
+   * @returns {boolean}
+   */
+  static _insertViaPaste(inputBox, text) {
+    if (InputBoxHandler._avoidSyntheticPaste()) return false;
+    const before = InputBoxHandler._readPlainText(inputBox);
+    try {
+      const dataTransfer = new DataTransfer();
+      dataTransfer.setData('text/plain', text);
+      const pasteEvent = new ClipboardEvent('paste', {
+        clipboardData: dataTransfer,
+        bubbles: true,
+        cancelable: true,
+      });
+      inputBox.dispatchEvent(pasteEvent);
+      const after = InputBoxHandler._readPlainText(inputBox);
+      return InputBoxHandler._textGained(before, after, text);
+    } catch (_) {
+      return false;
+    }
+  }
+
+  /**
+   * COMMENT: If ChatGPT/Perplexity echoed the prompt as a quote card, keep a single copy.
+   * @param {HTMLElement} inputBox
+   * @param {string} content
+   * @param {string} beforeText
+   * @param {boolean} disableOverwrite
+   */
+  static _collapseDuplicateIfNeeded(inputBox, content, beforeText, disableOverwrite) {
+    const utils = (typeof PromptInsertUtils !== 'undefined' && PromptInsertUtils)
+      || (typeof window !== 'undefined' && window.PromptInsertUtils);
+    if (!utils?.collapseDuplicatedPromptText) return;
+
+    const after = InputBoxHandler._readPlainText(inputBox);
+    const collapsed = utils.collapseDuplicatedPromptText(after, content, {
+      beforeText,
+      append: disableOverwrite,
+    });
+    if (collapsed === after || utils.normalizeEditorText(collapsed) === utils.normalizeEditorText(after)) {
+      return;
+    }
+
+    InputBoxHandler._focusAndSelect(inputBox, false);
+    try { document.execCommand('delete', false, null); } catch (_) { /* ignore */ }
+    InputBoxHandler._insertTextOnce(inputBox, collapsed);
+
+    const repaired = InputBoxHandler._readPlainText(inputBox);
+    if (utils.isQuotedDuplicatePrompt?.(repaired, content)
+      || utils.normalizeEditorText(repaired) !== utils.normalizeEditorText(collapsed)) {
+      // COMMENT: Repair insert also doubled — write once through the DOM as a last resort
+      if (inputBox.isContentEditable) {
+        inputBox.textContent = collapsed + '  ';
+        inputBox.dispatchEvent(new Event('input', { bubbles: true }));
+      }
+    }
+  }
+
+  /**
+   * COMMENT: Shared insert path for Lexical, Quill, and ProseMirror. Avoids paste+insertText doubles.
    * @param {HTMLElement} inputBox
    * @param {string} content
    * @param {boolean} disableOverwrite
    */
   static _insertViaExecCommand(inputBox, content, disableOverwrite) {
-    const selection = window.getSelection();
-    const range = document.createRange();
-    range.selectNodeContents(inputBox);
-    if (disableOverwrite) {
-      range.collapse(false);
-    }
-    selection.removeAllRanges();
-    selection.addRange(range);
+    const editor = InputBoxHandler._resolveRichEditor(inputBox) || inputBox;
+    const beforeInsertionText = InputBoxHandler._readPlainText(editor);
+    InputBoxHandler._focusAndSelect(editor, disableOverwrite);
 
     if (!disableOverwrite) {
-      document.execCommand('delete', false, null);
+      try { document.execCommand('delete', false, null); } catch (_) { /* ignore */ }
     }
 
-    const textToInsert = content + '  ';
-    // COMMENT: Multiline prompts need a paste-style event in Lexical editors (e.g. Perplexity).
-    // COMMENT: insertText can flatten newlines into a single paragraph.
-    const getPlainEditorText = () => inputBox.innerText || inputBox.textContent || '';
-    const beforeInsertionText = getPlainEditorText();
+    const trailing = '  ';
     let inserted = false;
 
     if (content.includes('\n')) {
+      inserted = true;
+      const lines = content.split('\n');
+      for (let i = 0; i < lines.length; i += 1) {
+        if (lines[i]) {
+          if (!InputBoxHandler._insertTextOnce(editor, lines[i])) inserted = false;
+        }
+        if (i < lines.length - 1) {
+          InputBoxHandler._insertLineBreak(editor);
+        }
+      }
+      InputBoxHandler._insertTextOnce(editor, trailing);
+      if (!InputBoxHandler._textGained(beforeInsertionText, InputBoxHandler._readPlainText(editor), content)) {
+        inserted = false;
+      }
+    } else {
+      inserted = InputBoxHandler._insertTextOnce(editor, content + trailing);
+    }
+
+    // COMMENT: Paste is a last resort and is skipped on ChatGPT/Perplexity (quote/attachment hosts)
+    if (!inserted) {
+      inserted = InputBoxHandler._insertViaPaste(editor, content + trailing);
+    }
+
+    if (!inserted) {
       try {
-        const dataTransfer = new DataTransfer();
-        dataTransfer.setData('text/plain', textToInsert);
-        const pasteEvent = new ClipboardEvent('paste', {
-          clipboardData: dataTransfer,
+        editor.dispatchEvent(new InputEvent('beforeinput', {
+          inputType: 'insertText',
+          data: content + trailing,
           bubbles: true,
           cancelable: true,
-        });
-        inputBox.dispatchEvent(pasteEvent);
-        const afterPasteText = getPlainEditorText();
-        inserted = afterPasteText.length > beforeInsertionText.length;
+        }));
+        editor.dispatchEvent(new Event('input', { bubbles: true }));
       } catch (_) {
-        inserted = false;
+        // ignore
       }
     }
 
-    // COMMENT: Primary single-line path, and fallback when synthetic paste is ignored.
-    if (!inserted) {
-      try {
-        inserted = document.execCommand('insertText', false, textToInsert);
-      } catch (_) {
-        // COMMENT: execCommand may be unavailable in some editor contexts
-        inserted = false;
-      }
-    }
-
-    if (!inserted) {
-      inputBox.dispatchEvent(new InputEvent('beforeinput', {
-        inputType: content.includes('\n') ? 'insertFromPaste' : 'insertText',
-        data: textToInsert,
-        bubbles: true,
-        cancelable: true,
-      }));
-      inputBox.dispatchEvent(new Event('input', { bubbles: true }));
-    }
+    InputBoxHandler._collapseDuplicateIfNeeded(editor, content, beforeInsertionText, disableOverwrite);
 
     const endRange = document.createRange();
-    endRange.selectNodeContents(inputBox);
+    endRange.selectNodeContents(editor);
     endRange.collapse(false);
     const sel = window.getSelection();
     sel.removeAllRanges();
     sel.addRange(endRange);
-    inputBox.dispatchEvent(new Event('change', { bubbles: true }));
+    editor.dispatchEvent(new Event('change', { bubbles: true }));
   }
 
   /**
@@ -1146,25 +1359,15 @@ class InputBoxHandler {
       });
 
       if (inputBox.isContentEditable) {
-        const isLexicalEditor = inputBox.getAttribute('data-lexical-editor') === 'true'
-          || !!inputBox.closest('[data-lexical-editor="true"]')
-          || inputBox.id === 'ask-input';
-
-        const isQuillEditor = inputBox.classList.contains('ql-editor')
-          || !!inputBox.closest('.ql-container')
-          || !!inputBox.closest('rich-textarea');
-
-        const isProseMirrorEditor =
-          (inputBox.classList && inputBox.classList.contains('ProseMirror')) ||
-          (typeof inputBox.closest === 'function' && !!inputBox.closest('.ProseMirror'));
-
-        // COMMENT: Quill (Gemini), Lexical, and ProseMirror respond reliably to execCommand insertText
-        if (isLexicalEditor || isQuillEditor || isProseMirrorEditor) {
-          InputBoxHandler._insertViaExecCommand(inputBox, content, disableOverwrite);
+        const editor = InputBoxHandler._resolveRichEditor(inputBox);
+        // COMMENT: Nested ProseMirror/Lexical (ChatGPT/Perplexity wrappers) must use the rich path
+        if (InputBoxHandler._isRichEditor(editor) || InputBoxHandler._isRichEditor(inputBox)) {
+          InputBoxHandler._insertViaExecCommand(editor, content, disableOverwrite);
           PromptUIManager.hidePromptList(promptList);
           return;
         }
 
+        const beforeInsertionText = InputBoxHandler._readPlainText(inputBox);
         if (disableOverwrite) {
           const endRange = document.createRange();
           endRange.selectNodeContents(inputBox);
@@ -1191,17 +1394,7 @@ class InputBoxHandler {
             inputBox.appendChild(document.createTextNode(prefix + content));
           }
         } else {
-          inputBox.innerHTML = '';
-
-          const dataTransfer = new DataTransfer();
-          dataTransfer.setData('text/plain', content);
-          const pasteEvent = new ClipboardEvent('paste', {
-            clipboardData: dataTransfer,
-            bubbles: true,
-            cancelable: true,
-          });
-          inputBox.dispatchEvent(pasteEvent);
-
+          // COMMENT: Write once. Do not paste then also set textContent — that duplicates on ChatGPT/Perplexity.
           if (content.includes('\n')) {
             const lines = content.split('\n');
             inputBox.innerHTML = '';
@@ -1237,6 +1430,8 @@ class InputBoxHandler {
           inputBox.innerText = content + '  ';
           inputBox.dispatchEvent(new Event('input', { bubbles: true }));
         }
+
+        InputBoxHandler._collapseDuplicateIfNeeded(inputBox, content, beforeInsertionText, disableOverwrite);
       } else if (inputBox.tagName.toLowerCase() === 'textarea' || inputBox.tagName.toLowerCase() === 'input') {
         if (disableOverwrite) {
           const existing = inputBox.value || '';

--- a/src/llm_providers.json
+++ b/src/llm_providers.json
@@ -5,7 +5,7 @@
       "pattern": "*://chatgpt.com/*",
       "url": "https://chatgpt.com",
       "icon_url": "https://cdn.oaistatic.com/assets/favicon-miwirzcw.ico",
-      "element_selector": "#prompt-textarea, textarea[data-id='root-textarea'], textarea[placeholder*='Message'], textarea"
+      "element_selector": "#prompt-textarea, [data-testid='prompt-textarea'], div.ProseMirror[contenteditable='true'], textarea[data-id='root-textarea'], textarea[placeholder*='Message']"
     },
     {
       "name": "NotebookLM",
@@ -110,7 +110,7 @@
       "pattern": "*://www.perplexity.ai/*",
       "url": "https://www.perplexity.ai",
       "icon_url": "../icons/perplexity-icon.png",
-      "element_selector": "#ask-input"
+      "element_selector": "#ask-input, [data-lexical-editor='true'][contenteditable='true']"
     },
     {
       "name": "LMArena",

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -18,6 +18,7 @@ import { resolveProviderIconUrl } from './utils/providerIcons.js';
 
 // COMMENT: Single source of truth for dynamically injected content-script bundles
 const CONTENT_SCRIPT_FILES = [
+  'utils/promptInsertUtils.js',
   'handlers/inputBoxHandler.js',
   'content.styles.js',
   'content.shared.js',

--- a/src/utils/promptInsertUtils.js
+++ b/src/utils/promptInsertUtils.js
@@ -1,0 +1,124 @@
+// promptInsertUtils.js
+// COMMENT: Pure helpers for prompt insertion. Shared by the content-script handler and unit tests.
+
+(function attachPromptInsertUtils(root) {
+  /**
+   * COMMENT: Escape a string for safe use in a RegExp.
+   * @param {string} value
+   * @returns {string}
+   */
+  function escapeRegExp(value) {
+    return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  /**
+   * COMMENT: Normalize editor whitespace so quote/attachment duplicates compare reliably.
+   * @param {string} value
+   * @returns {string}
+   */
+  function normalizeEditorText(value) {
+    return String(value || '')
+      .replace(/\u00a0/g, ' ')
+      .replace(/\r\n/g, '\n')
+      .replace(/[ \t]+\n/g, '\n')
+      .trim();
+  }
+
+  /**
+   * COMMENT: Hosts that turn synthetic paste into a quote card or paste.txt attachment.
+   * @param {string} hostname
+   * @returns {boolean}
+   */
+  function siteConvertsPasteToAttachment(hostname) {
+    const host = String(hostname || '').toLowerCase();
+    return /(?:^|\.)chatgpt\.com$|(?:^|\.)chat\.openai\.com$|(?:^|\.)perplexity\.ai$/.test(host);
+  }
+
+  /**
+   * COMMENT: True when editor text is the prompt plus a second quoted/attached copy.
+   * Matches the ChatGPT/Perplexity report:
+   *   prompt
+   *   ---
+   *   >prompt--->
+   * @param {string} editorText
+   * @param {string} prompt
+   * @returns {boolean}
+   */
+  function isQuotedDuplicatePrompt(editorText, prompt) {
+    const needle = normalizeEditorText(prompt);
+    const text = normalizeEditorText(editorText);
+    if (!needle || !text) return false;
+    if (text === needle) return false;
+
+    const escaped = escapeRegExp(needle);
+    const quotedDuplicate = new RegExp(
+      `^${escaped}\\s*(?:\\n+---+\\s*)?\\n+>${escaped}(?:--->)?\\s*$`
+    );
+    if (quotedDuplicate.test(text)) return true;
+
+    const occurrences = text.match(new RegExp(escaped, 'g'));
+    if (!occurrences || occurrences.length < 2) return false;
+
+    let remainder = text;
+    remainder = remainder.replace(needle, '');
+    remainder = remainder.replace(needle, '');
+    // COMMENT: Leftover quote markers, hr separators, and caret-like arrows from paste cards
+    const junk = remainder.replace(/[\s>`\-–—:~*]+/g, '');
+    return junk.length === 0;
+  }
+
+  /**
+   * COMMENT: Collapse a duplicated insert down to a single copy of the prompt.
+   * Returns the original string when the editor does not look like a duplicate.
+   * @param {string} editorText
+   * @param {string} prompt
+   * @param {{ beforeText?: string, append?: boolean }} [options]
+   * @returns {string}
+   */
+  function collapseDuplicatedPromptText(editorText, prompt, options) {
+    const original = editorText == null ? '' : String(editorText);
+    const needle = normalizeEditorText(prompt);
+    if (!needle) return original;
+
+    const append = Boolean(options?.append);
+    const beforeText = normalizeEditorText(options?.beforeText || '');
+    const text = normalizeEditorText(original);
+    const expected = append
+      ? normalizeEditorText(`${beforeText}${beforeText && !/\s$/.test(beforeText) ? ' ' : ''}${needle}`)
+      : needle;
+
+    if (text === expected) return original;
+
+    const suffix = append && beforeText && text.startsWith(beforeText)
+      ? text.slice(beforeText.length).trim()
+      : text;
+
+    if (isQuotedDuplicatePrompt(suffix, needle) || isQuotedDuplicatePrompt(text, needle)) {
+      return expected;
+    }
+
+    // COMMENT: Plain concatenation of the same prompt twice (Lexical execCommand double-insert)
+    if (!append && (text === `${needle}${needle}` || text === `${needle}  ${needle}` || text === `${needle}\n${needle}`)) {
+      return needle;
+    }
+    if (!append && text.startsWith(needle) && text.endsWith(needle) && text.length > needle.length) {
+      const middle = text.slice(needle.length, text.length - needle.length);
+      if (/^[\s>`\-–—:~*]*$/.test(middle)) return needle;
+    }
+
+    return original;
+  }
+
+  const PromptInsertUtils = {
+    escapeRegExp,
+    normalizeEditorText,
+    siteConvertsPasteToAttachment,
+    isQuotedDuplicatePrompt,
+    collapseDuplicatedPromptText,
+  };
+
+  root.PromptInsertUtils = PromptInsertUtils;
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = PromptInsertUtils;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/tests/promptInsertUtils.test.js
+++ b/tests/promptInsertUtils.test.js
@@ -1,0 +1,51 @@
+const {
+  collapseDuplicatedPromptText,
+  isQuotedDuplicatePrompt,
+  siteConvertsPasteToAttachment,
+  normalizeEditorText,
+} = require('../src/utils/promptInsertUtils.js');
+
+describe('prompt insert duplicate collapse', () => {
+  const prompt = 'write an evocative spiritual prose poem based on this PASSAGE:';
+
+  test('leaves a single copy unchanged', () => {
+    expect(collapseDuplicatedPromptText(`${prompt}  `, prompt)).toBe(`${prompt}  `);
+    expect(isQuotedDuplicatePrompt(prompt, prompt)).toBe(false);
+  });
+
+  test('collapses the ChatGPT/Perplexity quoted paste-card duplicate', () => {
+    const duplicated = `${prompt}\n---\n>${prompt}--->`;
+    expect(isQuotedDuplicatePrompt(duplicated, prompt)).toBe(true);
+    expect(collapseDuplicatedPromptText(duplicated, prompt)).toBe(prompt);
+  });
+
+  test('collapses a markdown blockquote duplicate without the trailing arrow', () => {
+    const duplicated = `${prompt}\n---\n>${prompt}`;
+    expect(collapseDuplicatedPromptText(duplicated, prompt)).toBe(prompt);
+  });
+
+  test('collapses a plain concatenated double insert', () => {
+    expect(collapseDuplicatedPromptText(`${prompt}${prompt}`, prompt)).toBe(prompt);
+    expect(collapseDuplicatedPromptText(`${prompt}\n${prompt}`, prompt)).toBe(prompt);
+  });
+
+  test('does not collapse unrelated text that merely contains the prompt once', () => {
+    const other = `${prompt}\n\nPlease keep the original line breaks.`;
+    expect(collapseDuplicatedPromptText(other, prompt)).toBe(other);
+  });
+
+  test('in append mode only inspects the newly inserted suffix', () => {
+    const before = 'already in the box';
+    const duplicated = `${before} ${prompt}\n---\n>${prompt}`;
+    expect(collapseDuplicatedPromptText(duplicated, prompt, { beforeText: before, append: true }))
+      .toBe(`${before} ${prompt}`);
+  });
+
+  test('identifies ChatGPT and Perplexity as paste-to-attachment hosts', () => {
+    expect(siteConvertsPasteToAttachment('chatgpt.com')).toBe(true);
+    expect(siteConvertsPasteToAttachment('www.perplexity.ai')).toBe(true);
+    expect(siteConvertsPasteToAttachment('chat.openai.com')).toBe(true);
+    expect(siteConvertsPasteToAttachment('gemini.google.com')).toBe(false);
+    expect(normalizeEditorText('  a\u00a0b  ')).toBe('a b');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

When inserting a saved prompt from the prompt manager, ChatGPT and Perplexity could post the same prompt twice. The second copy showed up as a quoted/attachment-style block, for example:

```
write an evocative spiritual prose poem based on this PASSAGE:
---
>write an evocative spiritual prose poem based on this PASSAGE:--->
```

Those sites now treat synthetic `paste` events as a quote card or `paste.txt` attachment. The extension was also writing the same text a second time (`paste` + `insertText`/`textContent`), so the composer ended up with both copies.

## Fix

- Insert prompt text **once** through `beforeinput` / `execCommand('insertText')`.
- Preserve multiline prompts with line-break commands instead of paste.
- **Skip synthetic paste** on ChatGPT and Perplexity.
- Detect nested ProseMirror/Lexical editors (wrapper `#prompt-textarea` / `#ask-input`).
- Collapse a leftover quote-card duplicate if a host still echoes the prompt.
- Ignore rapid double-selects from click + keyboard.

## Testing

- `npx eslint src` — pass
- `npx jest tests/promptInsertUtils.test.js` — 7 tests pass, including the reported quote-card duplicate

Manual check recommended:

1. Load the extension from this branch.
2. On Perplexity, insert a saved prompt and confirm it appears once.
3. Repeat on ChatGPT.
4. Repeat with a multiline prompt and with “Append prompts to text” enabled.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01dee-773d-787c-a590-eeaad84ba76d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01dee-773d-787c-a590-eeaad84ba76d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

