### PR TITLE
Fix OPD share, shortcut matching, Perplexity host, and 2.9.1 docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog],
 and this project adheres to [Semantic Versioning].
 
+## [Unreleased]
+
+### Fixed
+
+- Sharing an imported catalog prompt now publishes your copy instead of returning success for the original row.
+- Re-importing a catalog prompt that is already in the library no longer increments the import counter.
+- The side panel shows an error toast when Share to Open Prompt Database fails.
+- The in-page keyboard shortcut requires an exact Shift match (`Ctrl+M` no longer also matches `Ctrl+Shift+M`).
+- Variable prompts re-detect the chat input before inserting, so SPA composer replacements do not swallow the filled prompt.
+- Perplexity apex host `perplexity.ai` is recognized for injection and permissions, not only `www.perplexity.ai`.
+
+## [2.9.1]
+
+### Added
+
+- Share local prompts to the Open Prompt Database from the side panel.
+- Publisher handle and publish toggle in Open Prompt Database settings.
+
+## [2.9] - 2026-05-25
+
+### Added
+
+- Import community prompts from the Open Prompt Database into the local library.
+- Stable `opd:` ids so re-import updates the same prompt when the catalog entry changes.
+- Duplicate detection on the catalog site (“Already in library”).
+- Settings link to browse the community catalog.
+
 ## [2.8] - 2026-05-25
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A lightweight, open-source Chrome extension for saving, organizing, and inserting prompts across AI chatbots — ChatGPT, Claude, Gemini, Grok, and [17+ more platforms](#supported-platforms).
 
-**Current version:** 2.9 · [Chrome Web Store](https://chromewebstore.google.com/detail/open-prompt-manager/gmhaghdbihgenofhnmdbglbkbplolain) · [Open Prompt Database](https://openpromptdatabase.com/)
+**Current version:** 2.9.1 · [Chrome Web Store](https://chromewebstore.google.com/detail/open-prompt-manager/gmhaghdbihgenofhnmdbglbkbplolain) · [Open Prompt Database](https://openpromptdatabase.com/)
 
 ## Features
 
@@ -26,10 +26,11 @@ A lightweight, open-source Chrome extension for saving, organizing, and insertin
 
 ### Open Prompt Database
 
-Browse community prompts on the [Open Prompt Database](https://openpromptdatabase.com/) and add them to your library with one click.
+Browse community prompts on the [Open Prompt Database](https://openpromptdatabase.com/) and add them to your library with one click. Share your own prompts from the **side panel**.
 
 - Stable `opd:` ids — re-import updates the same prompt when the catalog entry changes
 - Duplicate detection — already in your library? The site shows “Already in library”
+- **Share to Open Prompt Database** publishes a prompt you choose (title, content, tags) under your publisher handle
 - Link from Settings → **Browse the community catalog**
 
 ### Settings & permissions
@@ -77,7 +78,8 @@ Automated tests use **Puppeteer** and **Jest**. See the [Testing Guide](TESTING.
 ## Privacy
 
 - Your prompt library is stored **locally** in the browser (`chrome.storage.local`)
-- Nothing is sent to external servers unless **you** choose to import from the [Open Prompt Database](https://openpromptdatabase.com/) — that flow only pulls the prompt you selected into your local library
+- Catalog **import** pulls a prompt you selected from the [Open Prompt Database](https://openpromptdatabase.com/) into your local library
+- Catalog **share / upload** sends a prompt you choose (title, content, tags) to Open Prompt Database under your publisher handle. That only happens when you click **Share to Open Prompt Database**
 - No analytics or tracking
 
 ## License

--- a/src/changelog.html
+++ b/src/changelog.html
@@ -34,6 +34,14 @@
 
 <div class="opm-changelog" style="display: flex; flex-direction: column; gap: 16px;">
 
+    <div style="font-weight: bold; margin-bottom: 4px;">Version 2.9.1</div>
+    <div>
+    <ul>
+      <li><strong>Share to Open Prompt Database</strong>: publish a prompt from the side panel under your publisher handle (title, content, tags). Catalog import remains one-click from the database site.</li>
+      <li>Publisher handle and publish toggle in Open Prompt Database settings.</li>
+    </ul>
+  </div>
+
     <div style="font-weight: bold; margin-bottom: 4px;">Version 2.9</div>
     <div>
     <ul>

--- a/src/content.js
+++ b/src/content.js
@@ -577,14 +577,27 @@ class KeyboardManager {
     KeyboardManager._attachShortcutWatcher();
   }
 
+  /**
+   * COMMENT: Require the exact stored modifiers so extra Shift/Alt/Meta does not steal host keys.
+   * @param {KeyboardEvent} e
+   * @param {{ key?: string, modifier?: string, requiresShift?: boolean }|null} shortcut
+   * @returns {boolean}
+   */
+  static _shortcutMatches(e, shortcut) {
+    if (!shortcut?.key || !shortcut?.modifier) return false;
+    if (!e[shortcut.modifier]) return false;
+    if (e.altKey) return false;
+    const otherMod = shortcut.modifier === 'metaKey' ? 'ctrlKey' : 'metaKey';
+    if (e[otherMod]) return false;
+    if (Boolean(e.shiftKey) !== Boolean(shortcut.requiresShift)) return false;
+    return e.key.toLowerCase() === String(shortcut.key).toLowerCase();
+  }
+
   static async _onKeyDown(e) {
     const shortcut = KeyboardManager.shortcutCache || await PromptStorageManager.getKeyboardShortcut();
     if (!KeyboardManager.shortcutCache && shortcut) KeyboardManager.shortcutCache = shortcut;
-    // COMMENT: Match the configured modifier + optional shift + key for open/close toggle
-    const modifierMatches = Boolean(shortcut?.modifier && e[shortcut.modifier]);
-    const shiftMatches = shortcut?.requiresShift ? e.shiftKey : true;
-    const keyMatches = shortcut?.key && e.key.toLowerCase() === String(shortcut.key).toLowerCase();
-    if (modifierMatches && shiftMatches && keyMatches) {
+    // COMMENT: Exact modifier match — Ctrl+M must not also fire for Ctrl+Shift+M
+    if (!e.isComposing && !e.repeat && KeyboardManager._shortcutMatches(e, shortcut)) {
       e.preventDefault();
       KeyboardManager._togglePromptList();
       return;
@@ -2185,7 +2198,23 @@ const PromptMediator = (() => {
       variables: vars,
       onSubmit: async values => {
         const processed = state.processor.replaceVariables(prompt.content, values);
-        await window.InputBoxHandler.insertPrompt(inputBox, processed, qs(`#${SELECTORS.PROMPT_LIST}`));
+        // COMMENT: ChatGPT/Perplexity often replace the composer while the variable form is open
+        if (typeof window.InputBoxHandler._invalidateInputCache === 'function') {
+          window.InputBoxHandler._invalidateInputCache();
+        }
+        let targetBox = await window.InputBoxHandler.getInputBox();
+        if (!targetBox?.isConnected) {
+          try {
+            targetBox = await window.InputBoxHandler.waitForInputBox();
+          } catch (_) {
+            targetBox = inputBox?.isConnected ? inputBox : null;
+          }
+        }
+        if (!targetBox) {
+          console.error('Input box not found.');
+          return;
+        }
+        await window.InputBoxHandler.insertPrompt(targetBox, processed, qs(`#${SELECTORS.PROMPT_LIST}`));
         const activeList = qs(`#${SELECTORS.PROMPT_LIST}`);
         if (activeList) PromptUIManager.hidePromptList(activeList);
         setTimeout(() => {

--- a/src/handlers/inputBoxHandler.js
+++ b/src/handlers/inputBoxHandler.js
@@ -1004,9 +1004,12 @@ class InputBoxHandler {
 
     for (const provider of providers) {
       if (!provider.pattern) continue;
-      const pattern = provider.pattern.replace(/\*/g, '.*');
-      const regex = new RegExp(pattern, 'i');
-      if (!regex.test(window.location.href)) continue;
+      const originPatterns = String(provider.pattern).split(',').map((item) => item.trim()).filter(Boolean);
+      const matchesHost = originPatterns.some((originPattern) => {
+        const regex = new RegExp(originPattern.replace(/\*/g, '.*'), 'i');
+        return regex.test(window.location.href);
+      });
+      if (!matchesHost) continue;
 
       matchedProvider = provider;
       if (provider.element_selector) {

--- a/src/llm_providers.js
+++ b/src/llm_providers.js
@@ -1,3 +1,5 @@
+import { expandOriginPatterns } from './utils/originPatterns.js';
+
 export async function getProviders() {
   try {
     const response = await fetch(chrome.runtime.getURL('llm_providers.json'));
@@ -16,7 +18,8 @@ export async function getProviders() {
       return acc;
     }, {});
 
-    const patternsArray = data.llm_providers.map(item => item.pattern);
+    // COMMENT: A provider may list several comma-separated Chrome origin patterns
+    const patternsArray = data.llm_providers.flatMap((item) => expandOriginPatterns(item.pattern));
 
     return { patternsObject, patternsArray };
   } catch (error) {

--- a/src/llm_providers.json
+++ b/src/llm_providers.json
@@ -107,7 +107,7 @@
     },
     {
       "name": "Perplexity AI",
-      "pattern": "*://www.perplexity.ai/*",
+      "pattern": "*://www.perplexity.ai/*,*://perplexity.ai/*",
       "url": "https://www.perplexity.ai",
       "icon_url": "../icons/perplexity-icon.png",
       "element_selector": "#ask-input"

--- a/src/opd/opdPublish.js
+++ b/src/opd/opdPublish.js
@@ -27,13 +27,17 @@ export function resolveCatalogClientId(local) {
 /**
  * @param {object} local — normalised prompt from storage
  */
-export function localPromptToCatalogBody(local) {
-  return {
-    id: resolveCatalogClientId(local),
+export function localPromptToCatalogBody(local, { forceNew = false } = {}) {
+  const body = {
     title: local.title,
     content: local.content,
     tags: Array.isArray(local.tags) ? local.tags : [],
   };
+  if (!forceNew) {
+    const id = resolveCatalogClientId(local);
+    if (id) body.id = id;
+  }
+  return body;
 }
 
 /**
@@ -92,12 +96,8 @@ export async function shareLocalPrompt(localUuid, turnstileToken = '') {
         return { ok: true, catalogId, url, reused: true };
       }
 
-      // COMMENT: Imported community prompt — link locally to the existing catalog row, no duplicate POST
-      await updatePrompt(localUuid, {
-        opdPublicId: catalogId,
-        opdLastPublishedAt: local.opdLastPublishedAt || remote.updatedAt || new Date().toISOString(),
-      });
-      return { ok: true, catalogId, url, reused: true, copiedExisting: true };
+      // COMMENT: Imported someone else's prompt — publish a new catalog row for this user's copy
+      return publishLocalPrompt(localUuid, turnstileToken, { forceNewCatalogRow: true });
     }
   }
 
@@ -109,7 +109,7 @@ export async function shareLocalPrompt(localUuid, turnstileToken = '') {
  * @param {string} [turnstileToken]
  * @returns {Promise<{ ok: boolean, catalogId?: string, url?: string, error?: string }>}
  */
-export async function publishLocalPrompt(localUuid, turnstileToken = '') {
+export async function publishLocalPrompt(localUuid, turnstileToken = '', { forceNewCatalogRow = false } = {}) {
   const registration = await ensurePublisherRegisteredForUpload();
   if (!registration.ok) {
     return { ok: false, error: registration.error || 'not_registered' };
@@ -126,7 +126,10 @@ export async function publishLocalPrompt(localUuid, turnstileToken = '') {
     return { ok: false, error: 'prompt_not_found' };
   }
 
-  const res = await publishPrompt(localPromptToCatalogBody(local), turnstileToken);
+  const res = await publishPrompt(
+    localPromptToCatalogBody(local, { forceNew: forceNewCatalogRow }),
+    turnstileToken,
+  );
   if (!res.ok || !res.data?.prompt?.id) {
     return { ok: false, error: res.data?.error || 'publish_failed' };
   }

--- a/src/permissions/permissions.js
+++ b/src/permissions/permissions.js
@@ -2,6 +2,11 @@
 // It retrieves the providers map from storage and creates elements for each provider
 document.addEventListener('DOMContentLoaded', function () {
 
+  // COMMENT: A provider may list several comma-separated Chrome origin patterns
+  function expandOriginPatterns(pattern) {
+    return String(pattern || '').split(',').map((item) => item.trim()).filter(Boolean);
+  }
+
   // COMMENT: Storage key shared with content-script display mode preference
   const DISPLAY_MODE_KEY = 'displayMode';
   const DEFAULT_DISPLAY_MODE = 'standard';
@@ -165,8 +170,10 @@ document.addEventListener('DOMContentLoaded', function () {
 
             const providerKey = this.dataset.provider;
             const originPattern = this.dataset.urlPattern;
+            const origins = expandOriginPatterns(originPattern);
+            if (!origins.length) return;
 
-            chrome.permissions.request({ origins: [originPattern] }, (granted) => {
+            chrome.permissions.request({ origins }, (granted) => {
               if (granted) {
                 // Update local providersMap and persist
                 providersMap[providerKey].hasPermission = 'Yes';
@@ -223,8 +230,7 @@ document.addEventListener('DOMContentLoaded', function () {
         // Collect all origin patterns (unique)
         const allPatterns = Array.from(new Set(
           Object.values(currentMap)
-            .map(v => v && v.urlPattern)
-            .filter(Boolean)
+            .flatMap((v) => expandOriginPatterns(v && v.urlPattern))
         ));
         // Attempt to remove all optional host permissions in one call
         try {

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -15,6 +15,7 @@ import {
 import { getPrompts, onPromptsChanged, savePrompt } from './storage/promptStorage.js';
 import { removePinnedForHostname } from './storage/pinnedInputStorage.js';
 import { resolveProviderIconUrl } from './utils/providerIcons.js';
+import { expandOriginPatterns, hasAnyOriginPermission } from './utils/originPatterns.js';
 
 // COMMENT: Single source of truth for dynamically injected content-script bundles
 const CONTENT_SCRIPT_FILES = [
@@ -123,7 +124,7 @@ async function syncStorageAfterPermissionRevoke(originPatterns) {
 
   for (const pattern of originPatterns) {
     Object.entries(providersMap).forEach(([name, info]) => {
-      if (info?.urlPattern === pattern) {
+      if (info?.urlPattern === pattern || expandOriginPatterns(info?.urlPattern).includes(pattern)) {
         providersMap[name] = { ...info, hasPermission: 'No' };
       }
     });
@@ -217,7 +218,8 @@ function handleOpdImportPrompt(message, sendResponse) {
   (async () => {
     try {
       const result = await importCatalogPrompt(message.prompt);
-      if (result?.ok && message.prompt?.id) {
+      // COMMENT: Only bump catalog import counts for a new or updated row, not "already in library"
+      if (result?.ok && message.prompt?.id && result.status !== 'already') {
         notifyPromptImported(message.prompt.id);
       }
       sendResponse(result);
@@ -534,10 +536,8 @@ async function checkProviderPermissions() {
       const urlPattern = providerInfo.pattern;
       const providerUrl = providerInfo.url;
 
-      // Check if permission exists for this provider's URL pattern
-      const hasPermission = await chrome.permissions.contains({
-        origins: [urlPattern]
-      });
+      // COMMENT: Grant if any listed origin is allowed (e.g. www + apex Perplexity)
+      const hasPermission = await hasAnyOriginPermission(urlPattern);
 
       // Store the result (permission status and URL) in providersMap
       providersMap[providerName] = {

--- a/src/settings.js
+++ b/src/settings.js
@@ -6,6 +6,7 @@ import {
   attachProviderIconFallback,
   getFaviconFallbackForUrl,
 } from './utils/providerIcons.js';
+import { expandOriginPatterns } from './utils/originPatterns.js';
 import { mountSidepanelFooter } from './sidepanel/sidepanelFooter.js';
 
 // COMMENT: Storage keys shared with the in-page panel and side panel
@@ -375,9 +376,10 @@ async function loadProviderMetadata() {
   const providersByPattern = new Map();
 
   Object.entries(providersMap).forEach(([name, info]) => {
-    if (info?.urlPattern) {
-      providersByPattern.set(info.urlPattern, { name, ...info });
-    }
+    if (!info?.urlPattern) return;
+    expandOriginPatterns(info.urlPattern).forEach((origin) => {
+      providersByPattern.set(origin, { name, ...info, urlPattern: origin });
+    });
   });
 
   if (providersByPattern.size === 0) {
@@ -387,12 +389,14 @@ async function loadProviderMetadata() {
       const list = Array.isArray(data?.llm_providers) ? data.llm_providers : [];
       list.forEach((provider) => {
         if (!provider?.pattern) return;
-        providersByPattern.set(provider.pattern, {
-          name: provider.name,
-          urlPattern: provider.pattern,
-          url: provider.url,
-          iconUrl: resolveProviderIconUrl(provider.icon_url, provider.url),
-          hasPermission: 'No',
+        expandOriginPatterns(provider.pattern).forEach((origin) => {
+          providersByPattern.set(origin, {
+            name: provider.name,
+            urlPattern: origin,
+            url: provider.url,
+            iconUrl: resolveProviderIconUrl(provider.icon_url, provider.url),
+            hasPermission: 'No',
+          });
         });
       });
     } catch (_) {
@@ -467,7 +471,7 @@ async function getGrantedSiteEntries() {
 function markProviderRevoked(providersMap, pattern) {
   const updated = { ...providersMap };
   Object.entries(updated).forEach(([name, info]) => {
-    if (info?.urlPattern === pattern) {
+    if (info?.urlPattern === pattern || expandOriginPatterns(info?.urlPattern).includes(pattern)) {
       updated[name] = { ...info, hasPermission: 'No' };
     }
   });

--- a/src/sidepanel/sidepanel.js
+++ b/src/sidepanel/sidepanel.js
@@ -9,6 +9,7 @@ import {
   getFaviconFallbackForUrl,
 } from '../utils/providerIcons.js';
 import { OPD_CATALOG_URL, OPD_MSG } from '../opd/opdConstants.js';
+import { expandOriginPatterns, hasAnyOriginPermission } from '../utils/originPatterns.js';
 import { mountSidepanelFooter } from './sidepanelFooter.js';
 
 /** @type {ReturnType<typeof collectPromptFormRefs>|null} */
@@ -487,10 +488,38 @@ async function publishPromptToOpd(localUuid) {
       }
       return true;
     }
+    showSidepanelToast(mapPublishError(res?.error), { error: true });
   } catch (_) {
-    // Ignore publish failures silently in the sidebar
+    showSidepanelToast(mapPublishError('publish_failed'), { error: true });
   }
   return false;
+}
+
+function mapPublishError(code) {
+  switch (code) {
+  case 'not_registered':
+    return 'Set a publisher handle in Open Prompt Database settings before sharing.';
+  case 'permission_denied':
+    return 'Catalog access is required to share. Grant permission and try again.';
+  case 'publish_disabled':
+    return 'Sharing is turned off in Open Prompt Database settings.';
+  case 'prompt_not_found':
+    return 'That prompt is no longer in your library.';
+  default:
+    return 'Could not share this prompt. Try again.';
+  }
+}
+
+function showSidepanelToast(message, { error = false } = {}) {
+  const existing = document.getElementById('spm-toast');
+  if (existing) existing.remove();
+  const toast = document.createElement('div');
+  toast.id = 'spm-toast';
+  toast.className = error ? 'spm-toast spm-toast-error' : 'spm-toast';
+  toast.setAttribute('role', 'status');
+  toast.textContent = message;
+  document.body.appendChild(toast);
+  window.setTimeout(() => toast.remove(), 3200);
 }
 
 // COMMENT: Share publish re-renders the list before feedback can paint — replay after rebuild
@@ -1129,7 +1158,7 @@ async function getProvidersMapOrFallback() {
     const computedEntries = await Promise.all(list.map(async (p) => {
       let permitted = false;
       try {
-        permitted = await chrome.permissions.contains({ origins: [p.pattern] });
+        permitted = await hasAnyOriginPermission(p.pattern);
       } catch (_) {
         permitted = false;
       }
@@ -1203,7 +1232,8 @@ async function renderLLMsSectionBody({ pinnedInputs: pinnedInputsOverride } = {}
         ev.preventDefault();
         const pattern = a.getAttribute('data-url-pattern');
         if (!pattern) return;
-        chrome.permissions.request({ origins: [pattern] }, (granted) => {
+        const origins = expandOriginPatterns(pattern);
+        chrome.permissions.request({ origins }, (granted) => {
           if (granted) {
             // Update storage map so both this UI and the permissions page stay in sync
             // Read, mutate, and write the aiProvidersMap

--- a/src/sidepanel/styles.css
+++ b/src/sidepanel/styles.css
@@ -307,6 +307,25 @@ html {
     color: #38a169;
   }
 
+  .spm-toast {
+    position: fixed;
+    bottom: 16px;
+    left: 50%;
+    transform: translateX(-50%);
+    z-index: 10000;
+    max-width: calc(100% - 24px);
+    padding: 10px 14px;
+    border-radius: 8px;
+    font: 500 13px/1.4 system-ui, sans-serif;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.18);
+    background: #1f1f1f;
+    color: #fff;
+  }
+
+  .spm-toast-error {
+    background: #c53030;
+  }
+
   .spm-prompt-action-btn:has(img[width="18"]) img {
     width: 18px;
     height: 18px;

--- a/src/utils/originPatterns.js
+++ b/src/utils/originPatterns.js
@@ -1,0 +1,31 @@
+/**
+ * Split comma-separated Chrome origin patterns used in llm_providers.json.
+ * @param {string} pattern
+ * @returns {string[]}
+ */
+export function expandOriginPatterns(pattern) {
+  return String(pattern || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+/**
+ * True when any of the origin patterns is already granted.
+ * @param {string|string[]} patternOrList
+ * @returns {Promise<boolean>}
+ */
+export async function hasAnyOriginPermission(patternOrList) {
+  const origins = Array.isArray(patternOrList)
+    ? patternOrList
+    : expandOriginPatterns(patternOrList);
+  for (const origin of origins) {
+    try {
+      const granted = await chrome.permissions.contains({ origins: [origin] });
+      if (granted) return true;
+    } catch (_) {
+      // Invalid pattern — skip
+    }
+  }
+  return false;
+}

--- a/tests/originPatterns.test.js
+++ b/tests/originPatterns.test.js
@@ -1,0 +1,24 @@
+const { llm_providers } = require('../src/llm_providers.json');
+
+function expandOriginPatterns(pattern) {
+  return String(pattern || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+describe('provider origin patterns', () => {
+  test('Perplexity lists both www and apex hosts', () => {
+    const provider = llm_providers.find((item) => item.name === 'Perplexity AI');
+    expect(provider).toBeTruthy();
+    const origins = expandOriginPatterns(provider.pattern);
+    expect(origins).toEqual(['*://www.perplexity.ai/*', '*://perplexity.ai/*']);
+  });
+
+  test('expandOriginPatterns ignores blanks', () => {
+    expect(expandOriginPatterns(' *://a.com/*, ,*://b.com/* ')).toEqual([
+      '*://a.com/*',
+      '*://b.com/*',
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to the bug scan: fixes OPD share/import, shortcut matching, variable insert, Perplexity apex matching, and docs/version drift. Separate from the ChatGPT/Perplexity duplicate-insert PR (#80).

## Changes

1. **Share no longer fake-succeeds on imported prompts.** If the catalog row belongs to someone else, Share publishes a **new** row for your copy/edits instead of returning `ok: true` for the original URL.
2. **Import counter.** Re-clicking “Add to Open Prompt Manager” when the prompt is already in the library (`status: already`) no longer POSTs `/import`.
3. **Silent share failures.** The side panel shows an error toast (`not_registered`, permission denied, network, etc.) instead of doing nothing.
6. **Shortcut matching.** `Ctrl+M` no longer also matches `Ctrl+Shift+M`. Extra Alt/Meta is ignored. The exact configured shortcut still works in the host composer so you can open the panel from ChatGPT.
7. **Variable prompts.** On submit, the composer is looked up again so a replaced ChatGPT/Perplexity/Gemini input does not swallow the filled prompt.
8. **Perplexity apex.** Injection and permissions match `perplexity.ai` as well as `www.perplexity.ai`.
9. **Version docs.** README is **2.9.1**. Changelog records 2.9 (import) and 2.9.1 (share). In-app `changelog.html` includes 2.9.1. GitHub Releases is still tagged 2.7 — publishing a 2.9.1 GitHub Release needs a human (CLI is read-only here).
10. **Privacy copy.** README now documents catalog **import** and **share/upload**, not import-only.

## Testing

- `npx eslint src`
- `npx jest tests/originPatterns.test.js`

Manual checks: Share an imported catalog prompt, re-import an existing one, fail a share (publish off), press `Ctrl+Shift+M` vs `Ctrl+M`, submit a `#variable#` prompt after navigating, open `https://perplexity.ai`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01dee-773d-787c-a590-eeaad84ba76d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01dee-773d-787c-a590-eeaad84ba76d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

