### PR TITLE
Fix handle-check errors, tag-input leaks, and related OPD gaps

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -489,8 +489,9 @@ const PanelRouter = (() => {
     const targetHeightMode = definition.panelHeight || 'fixed';
 
     const applyView = async () => {
-      // COMMENT: Drop tag-input document/window listeners before the form is replaced
+      // COMMENT: Drop tag-input / shortcut-recorder / reorder document listeners before the form is replaced
       window.TagUI?.destroyOpenInputs?.();
+      window.PromptUI?.abortTransientListeners?.();
 
       state.currentView = view;
       PromptUIManager.inVariableInputMode = (view === PanelView.VARIABLE_INPUT);
@@ -2051,6 +2052,7 @@ class PromptUIManager {
 
     // COMMENT: Drop cached view so the next open remounts into the fresh list container
     window.TagUI?.destroyOpenInputs?.();
+    window.PromptUI?.abortTransientListeners?.();
     PanelRouter.reset();
 
     // Clean up any other global handlers or state

--- a/src/content.js
+++ b/src/content.js
@@ -489,6 +489,9 @@ const PanelRouter = (() => {
     const targetHeightMode = definition.panelHeight || 'fixed';
 
     const applyView = async () => {
+      // COMMENT: Drop tag-input document/window listeners before the form is replaced
+      window.TagUI?.destroyOpenInputs?.();
+
       state.currentView = view;
       PromptUIManager.inVariableInputMode = (view === PanelView.VARIABLE_INPUT);
 
@@ -2047,6 +2050,7 @@ class PromptUIManager {
       });
 
     // COMMENT: Drop cached view so the next open remounts into the fresh list container
+    window.TagUI?.destroyOpenInputs?.();
     PanelRouter.reset();
 
     // Clean up any other global handlers or state

--- a/src/content.shared.js
+++ b/src/content.shared.js
@@ -229,6 +229,21 @@
         closeTimer: null
       };
 
+      // COMMENT: Document-level listeners that outlive a view must be aborted on remount
+      let shortcutRecordingHandler = null;
+      let abortReorderDrag = null;
+
+      const stopShortcutRecording = () => {
+        if (!shortcutRecordingHandler) return;
+        document.removeEventListener('keydown', shortcutRecordingHandler, true);
+        shortcutRecordingHandler = null;
+      };
+
+      const abortTransientListeners = () => {
+        stopShortcutRecording();
+        abortReorderDrag?.();
+      };
+
       const Elements = {
         createPanelContent() {
           return createEl('div', { id: SELECTORS.PANEL_CONTENT });
@@ -516,6 +531,8 @@
 
       const Reorder = {
         attach(promptsContainer, prompts, onReorder) {
+          abortReorderDrag?.();
+
           let isDragging = false;
           let dragSrcEl = null;
           let ghost = null;
@@ -536,6 +553,7 @@
             document.body.style.cursor = '';
             document.removeEventListener('mousemove', handleMouseMove);
             document.removeEventListener('mouseup', handleMouseUp);
+            if (abortReorderDrag === cleanup) abortReorderDrag = null;
           };
 
           const handleMouseMove = (e) => {
@@ -650,6 +668,7 @@
             });
           };
 
+          abortReorderDrag = cleanup;
           return { wireItem };
         }
       };
@@ -804,7 +823,6 @@
             innerHTML: '…'
           });
           const recordShortcutBtn = createEl('button', { innerHTML: 'Record', className: `opm-button opm-${getMode()}` });
-          let recordingHandler = null;
 
           const refreshShortcutDisplay = async () => {
             const shortcut = await window.PromptStorageManager.getKeyboardShortcut();
@@ -813,21 +831,19 @@
 
           recordShortcutBtn.addEventListener('click', (e) => {
             e.stopPropagation();
-            if (recordingHandler) {
-              document.removeEventListener('keydown', recordingHandler, true);
-              recordingHandler = null;
+            if (shortcutRecordingHandler) {
+              stopShortcutRecording();
               recordShortcutBtn.innerHTML = 'Record';
               refreshShortcutDisplay().catch(() => {});
               return;
             }
             recordShortcutBtn.innerHTML = 'Press keys…';
             shortcutDisplay.innerHTML = 'Listening…';
-            recordingHandler = async (event) => {
+            shortcutRecordingHandler = async (event) => {
               event.preventDefault();
               event.stopPropagation();
               if (event.key === 'Escape') {
-                document.removeEventListener('keydown', recordingHandler, true);
-                recordingHandler = null;
+                stopShortcutRecording();
                 recordShortcutBtn.innerHTML = 'Record';
                 refreshShortcutDisplay().catch(() => {});
                 return;
@@ -841,12 +857,11 @@
                 requiresShift: event.shiftKey,
                 key: event.key.length === 1 ? event.key.toLowerCase() : event.key.toLowerCase()
               });
-              document.removeEventListener('keydown', recordingHandler, true);
-              recordingHandler = null;
+              stopShortcutRecording();
               recordShortcutBtn.innerHTML = 'Record';
               refreshShortcutDisplay().catch(() => {});
             };
-            document.addEventListener('keydown', recordingHandler, true);
+            document.addEventListener('keydown', shortcutRecordingHandler, true);
           });
           shortcutRow.append(recordShortcutBtn, shortcutDisplay);
           refreshShortcutDisplay().catch(() => {});
@@ -1322,7 +1337,7 @@
         }
       };
 
-      return Object.freeze({ State, Elements, Views, Behaviors, Events });
+      return Object.freeze({ State, Elements, Views, Behaviors, Events, abortTransientListeners });
     })();
     window.PromptUI = PromptUI;
   }

--- a/src/content.shared.js
+++ b/src/content.shared.js
@@ -85,6 +85,8 @@
     window.TagService = TagService;
 
     const TagUI = (() => {
+      const openInputs = new Set();
+
       const createTagInput = ({ initialTags = [] } = {}) => {
         const tagsSet = new Set(Array.isArray(initialTags) ? initialTags : []);
         const row = createEl('div', { className: `opm-tag-row opm-${getMode()}` });
@@ -92,6 +94,7 @@
         const input = createEl('input', { attributes: { type: 'text', placeholder: 'Enter tags here.' }, className: `opm-tag-input opm-${getMode()}` });
         const suggestions = createEl('div', { className: `opm-tag-suggestions opm-${getMode()}`, styles: { display: 'none' } });
         let activeIndex = -1; let options = [];
+        let destroyed = false;
 
         const renderPills = () => {
           pills.innerHTML = '';
@@ -183,16 +186,39 @@
         });
         input.addEventListener('focus', () => { suggestions.style.display = 'none'; });
         input.addEventListener('blur', () => { suggestions.style.display = 'none'; });
-        document.addEventListener('click', (evt) => { if (!suggestions.contains(evt.target)) suggestions.style.display = 'none'; });
-        window.addEventListener('resize', positionSuggestions);
-        window.addEventListener('scroll', positionSuggestions, true);
+
+        // COMMENT: Named listeners so destroy() can detach them when the form is replaced
+        const onDocumentClick = (evt) => {
+          if (!suggestions.contains(evt.target)) suggestions.style.display = 'none';
+        };
+        const onWindowResize = () => positionSuggestions();
+        const onWindowScroll = () => positionSuggestions();
+        document.addEventListener('click', onDocumentClick);
+        window.addEventListener('resize', onWindowResize);
+        window.addEventListener('scroll', onWindowScroll, true);
+
+        const destroy = () => {
+          if (destroyed) return;
+          destroyed = true;
+          document.removeEventListener('click', onDocumentClick);
+          window.removeEventListener('resize', onWindowResize);
+          window.removeEventListener('scroll', onWindowScroll, true);
+          if (suggestions.parentElement) suggestions.parentElement.removeChild(suggestions);
+          openInputs.delete(api);
+        };
 
         renderPills();
         row.append(pills, input);
-        return { element: row, getTags: () => Array.from(tagsSet) };
+        const api = { element: row, getTags: () => Array.from(tagsSet), destroy };
+        openInputs.add(api);
+        return api;
       };
 
-      return { createTagInput };
+      const destroyOpenInputs = () => {
+        Array.from(openInputs).forEach((tagInput) => tagInput.destroy());
+      };
+
+      return { createTagInput, destroyOpenInputs };
     })();
     window.TagUI = TagUI;
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -44,7 +44,8 @@
     "host_permissions": [],
     "optional_host_permissions": [
         "<all_urls>",
-        "https://openpromptdatabase.com/*"
+        "https://openpromptdatabase.com/*",
+        "https://www.openpromptdatabase.com/*"
     ],
     "externally_connectable": {
         "matches": [

--- a/src/opd/opdCatalogAccess.js
+++ b/src/opd/opdCatalogAccess.js
@@ -8,6 +8,7 @@ import { OPD_CATALOG_URL } from './opdConstants.js';
 /** Keep in sync with manifest optional_host_permissions + externally_connectable. */
 export const OPD_CATALOG_ORIGINS = [
   'https://openpromptdatabase.com/*',
+  'https://www.openpromptdatabase.com/*',
   'http://localhost:8787/*',
   'http://127.0.0.1:8787/*',
 ];
@@ -139,7 +140,8 @@ export function initOpdCatalogAccess() {
 
   chrome.permissions.onRemoved.addListener((perms) => {
     if (perms.origins?.some((o) => OPD_CATALOG_ORIGINS.includes(o))) {
-      unregisterOpdBridgeContentScript().catch(console.error);
+      // COMMENT: Re-evaluate remaining origins — don't tear down the bridge if another catalog host is still granted
+      syncOpdCatalogAccess().catch(console.error);
     }
   });
 

--- a/src/opd/opdPublish.js
+++ b/src/opd/opdPublish.js
@@ -99,6 +99,11 @@ export async function shareLocalPrompt(localUuid, turnstileToken = '') {
       });
       return { ok: true, catalogId, url, reused: true, copiedExisting: true };
     }
+
+    // COMMENT: Known catalog id but lookup failed — don't POST a duplicate (404 means recreate)
+    if (existing.status !== 404) {
+      return { ok: false, error: 'catalog_lookup_failed' };
+    }
   }
 
   return publishLocalPrompt(localUuid, turnstileToken);

--- a/src/opd/opdPublisher.js
+++ b/src/opd/opdPublisher.js
@@ -74,6 +74,9 @@ export async function ensurePublisherRegisteredForUpload() {
   let handle = await getOrCreatePendingUsername();
   for (let attempt = 0; attempt < 5; attempt += 1) {
     const avail = await isHandleAvailable(handle);
+    if (!avail.ok) {
+      return { ok: false, error: avail.error || 'check_failed' };
+    }
     if (!avail.available) {
       handle = suggestRandomHandle();
       await setOpdPendingUsername(handle);
@@ -94,17 +97,22 @@ export async function ensurePublisherRegisteredForUpload() {
 
 /**
  * @param {string} handle
- * @returns {Promise<{ available: boolean, reason?: string }>}
+ * @returns {Promise<{ ok: boolean, available: boolean, reason?: string, error?: string }>}
  */
 export async function isHandleAvailable(handle) {
-  const res = await checkHandleAvailable(handle);
-  if (!res.ok || !res.data) {
-    return { available: false, reason: 'error' };
+  try {
+    const res = await checkHandleAvailable(handle);
+    if (!res.ok || !res.data) {
+      return { ok: false, available: false, error: 'check_failed' };
+    }
+    return {
+      ok: true,
+      available: Boolean(res.data.available),
+      reason: res.data.reason,
+    };
+  } catch (_) {
+    return { ok: false, available: false, error: 'check_failed' };
   }
-  return {
-    available: Boolean(res.data.available),
-    reason: res.data.reason,
-  };
 }
 
 /**

--- a/src/opd/opdSettingsPage.js
+++ b/src/opd/opdSettingsPage.js
@@ -14,6 +14,7 @@ import {
 import {
   getPublishSettings,
   setOpdPendingUsername,
+  clearOpdPendingUsername,
 } from './opdPublishToken.js';
 
 /**
@@ -172,6 +173,9 @@ export function initOpdSettingsPage(root = document) {
       const handle = normalizeHandleInput(els.handleInput);
       if (handle.length >= 3) {
         await setOpdPendingUsername(handle);
+      } else {
+        // COMMENT: Don't keep a stale draft handle after the user clears the field
+        await clearOpdPendingUsername();
       }
     });
   }

--- a/src/opd/opdSettingsPage.js
+++ b/src/opd/opdSettingsPage.js
@@ -195,8 +195,34 @@ export function initOpdSettingsPage(root = document) {
         els.handleStatus.classList.remove('settings-status-error');
       }
 
+      // COMMENT: Request catalog host access on the click gesture so the availability API can run
+      if (!(await hasOpdCatalogPermission())) {
+        const granted = await requestOpdCatalogPermission();
+        if (!granted) {
+          if (els.handleStatus) {
+            els.handleStatus.textContent = 'Catalog access is required to check handles.';
+            els.handleStatus.classList.add('settings-status-error');
+          }
+          els.handleConfirm.disabled = false;
+          return;
+        }
+        await syncOpdCatalogAccess();
+        await refreshCatalogAccessUi(els);
+      }
+
       const avail = await sendOpdMessage(OPD_MSG.HANDLE_AVAILABLE, { handle });
-      if (!avail?.ok || !avail.available) {
+      if (!avail?.ok) {
+        if (els.handleStatus) {
+          const permissionDenied = avail?.error === 'permission_denied';
+          els.handleStatus.textContent = permissionDenied
+            ? 'Catalog access is required to check handles.'
+            : 'Could not check that handle. Try again.';
+          els.handleStatus.classList.add('settings-status-error');
+        }
+        els.handleConfirm.disabled = false;
+        return;
+      }
+      if (!avail.available) {
         if (els.handleStatus) {
           els.handleStatus.textContent = 'Unavailable — try another.';
           els.handleStatus.classList.add('settings-status-error');
@@ -208,7 +234,9 @@ export function initOpdSettingsPage(root = document) {
       const reg = await sendOpdMessage(OPD_MSG.PUBLISH_REGISTER, { username: handle });
       if (!reg?.ok) {
         if (els.handleStatus) {
-          els.handleStatus.textContent = 'Could not confirm.';
+          els.handleStatus.textContent = reg?.error === 'permission_denied'
+            ? 'Catalog access is required to register a handle.'
+            : 'Could not confirm.';
           els.handleStatus.classList.add('settings-status-error');
         }
         els.handleConfirm.disabled = false;

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -3,6 +3,8 @@ import {
   initOpdCatalogAccess,
   isAllowedOpdMessageOrigin,
   hasOpdCatalogPermission,
+  requestOpdCatalogPermission,
+  syncOpdCatalogAccess,
 } from './opd/opdCatalogAccess.js';
 import { importCatalogPrompt } from './opd/opdImport.js';
 import { notifyPromptImported } from './opd/opdClient.js';
@@ -218,7 +220,8 @@ function handleOpdImportPrompt(message, sendResponse) {
   (async () => {
     try {
       const result = await importCatalogPrompt(message.prompt);
-      if (result?.ok && message.prompt?.id) {
+      // COMMENT: Count first-time imports only — re-import of an existing row is not a new import
+      if (result?.ok && result.status === 'imported' && message.prompt?.id) {
         notifyPromptImported(message.prompt.id);
       }
       sendResponse(result);
@@ -276,15 +279,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
       try {
         const enabled = Boolean(message.enabled);
         if (enabled) {
-          const granted = await new Promise((resolve) => {
-            chrome.permissions.request(
-              { origins: ['https://openpromptdatabase.com/*'] },
-              (ok) => resolve(Boolean(ok))
-            );
-          });
-          if (!granted) {
-            sendResponse({ ok: false, error: 'permission_denied' });
-            return;
+          if (!(await hasOpdCatalogPermission())) {
+            const granted = await requestOpdCatalogPermission();
+            if (!granted) {
+              sendResponse({ ok: false, error: 'permission_denied' });
+              return;
+            }
+            await syncOpdCatalogAccess();
           }
           await getOrCreatePublishToken();
         }
@@ -347,24 +348,13 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
           return;
         }
         // COMMENT: Optional host permission is requested on first share, same as enabling publish
-        const granted = await new Promise((resolve) => {
-          chrome.permissions.contains(
-            { origins: ['https://openpromptdatabase.com/*'] },
-            (hasPermission) => {
-              if (hasPermission) {
-                resolve(true);
-                return;
-              }
-              chrome.permissions.request(
-                { origins: ['https://openpromptdatabase.com/*'] },
-                (ok) => resolve(Boolean(ok))
-              );
-            }
-          );
-        });
-        if (!granted) {
-          sendResponse({ ok: false, error: 'permission_denied' });
-          return;
+        if (!(await hasOpdCatalogPermission())) {
+          const granted = await requestOpdCatalogPermission();
+          if (!granted) {
+            sendResponse({ ok: false, error: 'permission_denied' });
+            return;
+          }
+          await syncOpdCatalogAccess();
         }
         const result = await shareLocalPrompt(
           message.localUuid || '',

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -2,6 +2,7 @@ import { getProviders } from './llm_providers.js';
 import {
   initOpdCatalogAccess,
   isAllowedOpdMessageOrigin,
+  hasOpdCatalogPermission,
 } from './opd/opdCatalogAccess.js';
 import { importCatalogPrompt } from './opd/opdImport.js';
 import { notifyPromptImported } from './opd/opdClient.js';
@@ -299,7 +300,15 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message?.type === 'OPD_HANDLE_AVAILABLE') {
     (async () => {
       try {
+        if (!(await hasOpdCatalogPermission())) {
+          sendResponse({ ok: false, available: false, error: 'permission_denied' });
+          return;
+        }
         const result = await isHandleAvailable(message.handle || '');
+        if (!result.ok) {
+          sendResponse({ ok: false, available: false, error: result.error || 'check_failed' });
+          return;
+        }
         sendResponse({ ok: true, ...result });
       } catch (error) {
         sendResponse({ ok: false, error: error?.message || 'check_failed' });
@@ -311,6 +320,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (message?.type === 'OPD_PUBLISH_REGISTER') {
     (async () => {
       try {
+        if (!(await hasOpdCatalogPermission())) {
+          sendResponse({ ok: false, error: 'permission_denied' });
+          return;
+        }
         // COMMENT: Issue token for registration only — do not override the publish toggle
         await getOrCreatePublishToken();
         const result = await registerPublisherHandle(

--- a/src/sidepanel/sidepanel.js
+++ b/src/sidepanel/sidepanel.js
@@ -875,17 +875,23 @@ function createSidepanelTagInput({ initialTags = [] } = {}) {
   });
 
   input.addEventListener('blur', () => { suggestions.hidden = true; });
-  document.addEventListener('click', (evt) => {
+
+  // COMMENT: Named listeners so destroy() can detach them when the form is rebuilt
+  const onDocumentClick = (evt) => {
     if (!suggestions.contains(evt.target) && evt.target !== input) {
       suggestions.hidden = true;
     }
-  });
-  window.addEventListener('resize', positionSuggestions);
-  window.addEventListener('scroll', positionSuggestions, true);
+  };
+  const onWindowResize = () => positionSuggestions();
+  const onWindowScroll = () => positionSuggestions();
+  document.addEventListener('click', onDocumentClick);
+  window.addEventListener('resize', onWindowResize);
+  window.addEventListener('scroll', onWindowScroll, true);
 
   renderPills();
   row.append(pills, input);
 
+  let destroyed = false;
   return {
     element: row,
     getTags: () => Array.from(tagsSet),
@@ -898,6 +904,11 @@ function createSidepanelTagInput({ initialTags = [] } = {}) {
       renderPills();
     },
     destroy: () => {
+      if (destroyed) return;
+      destroyed = true;
+      document.removeEventListener('click', onDocumentClick);
+      window.removeEventListener('resize', onWindowResize);
+      window.removeEventListener('scroll', onWindowScroll, true);
       if (suggestions.parentElement) suggestions.parentElement.removeChild(suggestions);
     },
   };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The publish token stays in `chrome.storage.sync`. Moving it to local would break Chrome profile sync for the same publisher identity, so that change was dropped.

## Handle check
Checking a handle without catalog host permission (or when the availability API fails) was treated as “taken.” Confirm now requests catalog access on the click gesture, and the UI distinguishes:

- missing permission → “Catalog access is required to check handles.”
- API failure → “Could not check that handle. Try again.”
- actually taken → “Unavailable — try another.”

Upload registration also bails on a failed availability check instead of generating a new random handle.

## Tag input listeners
Create/edit tag fields attached `document` click and `window` resize/scroll listeners and never removed them when the form was replaced. Those listeners are now named, `destroy()` detaches them and removes the suggestions portal, and in-page panel remounts / UI teardown call `TagUI.destroyOpenInputs()`. The side panel form already destroyed the widget on rebuild; that destroy path now removes the listeners too.

## Follow-up findings (same PR)
- **www catalog host:** optional host permissions and `OPD_CATALOG_ORIGINS` now include `https://www.openpromptdatabase.com/*`. Enable/share use the same permission helpers as handle check instead of an apex-only inline request.
- **Bridge teardown:** removing one catalog origin re-syncs remaining access instead of always unregistering the bridge.
- **Import counter:** `/import` is notified only on first-time `imported`, not on duplicate re-imports.
- **Share lookup failure:** a known catalog id whose GET fails (non-404) no longer falls through to a new POST.
- **Pending handle:** clearing the handle field below 3 characters drops the synced draft instead of leaving a stale value.
- **More document listeners:** in-page shortcut recording and edit-mode reorder drag abort on panel remount / UI teardown.

## Left for other PRs
Duplicate ChatGPT/Perplexity insert is #80. Imported-prompt share UX, silent share toasts, shortcut Shift matching, variable-prompt composer re-detect, and Perplexity apex host are #81.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01dee-773d-787c-a590-eeaad84ba76d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01dee-773d-787c-a590-eeaad84ba76d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

