### PR TITLE
Add Firefox manifest build targets (from #79)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,7 @@ coverage/
 *.temp
 
 # Open Prompt Database website (private repo — clone separately)
-opd/ 
+opd/
+
+# Graphify output
+graphify-out/ 

--- a/README.md
+++ b/README.md
@@ -56,9 +56,21 @@ Plus any site you configure as a **custom website**.
 
 ### Load from source (development)
 
+**Chrome**
+
 1. Clone this repository
-2. Open `chrome://extensions`, enable **Developer mode**
-3. Click **Load unpacked** and select the `src/` folder
+2. Run `npm run build:chrome` (copies `src/manifest.chrome.json` → `src/manifest.json`)
+3. Open `chrome://extensions`, enable **Developer mode**
+4. Click **Load unpacked** and select the `src/` folder
+
+**Firefox (temporary add-on)**
+
+1. Run `npm run build:firefox`
+2. Open `about:debugging#/runtime/this-firefox`
+3. Click **Load Temporary Add-on...** and select `src/manifest.json`
+4. Run `npm run build:chrome` before packing a Chrome Web Store zip so `src/manifest.json` is the Chrome manifest again
+
+Firefox uses the native sidebar (`sidebar_action`) instead of Chrome's side panel. Open it from the Firefox sidebar UI; in-page launchers still work.
 
 ## Keyboard shortcuts
 
@@ -91,3 +103,4 @@ MIT License — see [LICENSE](LICENSE) if present in the repository.
 - **Hexodus** — bug reports and fixes
 - **Abdallahheidar** — ideas, contributions, and teamwork
 - **HideMaru** — extension icon ([Flaticon chatbot icons](https://www.flaticon.com/free-icons/chatbot))
+- **VolodymyrUhera** — Firefox / cross-browser manifest split ([#79](https://github.com/jonathanbertholet/promptmanager/pull/79))

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "scripts": {
         "test": "jest ./tests/",
         "debug": "node --inspect-brk node_modules/jest/bin/jest.js",
-        "build:prod": "cp src/manifest.prod.json src/manifest.json && echo 'Build for PROD'",
+        "build:chrome": "cp src/manifest.chrome.json src/manifest.json && echo 'Configured for Chrome'",
+        "build:firefox": "cp src/manifest.firefox.json src/manifest.json && echo 'Configured for Firefox'",
+        "build:prod": "cp src/manifest.chrome.json src/manifest.json && echo 'Build for PROD'",
         "lint": "eslint src",
         "lint:fix": "eslint src --fix"
     },

--- a/src/manifest.chrome.json
+++ b/src/manifest.chrome.json
@@ -1,0 +1,62 @@
+{
+    "manifest_version": 3,
+    "name": "Open Prompt Manager - for AI Agents & Assistants",
+    "version": "3.0.1",
+    "description": "Open Source Prompt Manager for ChatGPT, Claude, Gemini, Grok and more.",
+    "permissions": [
+        "sidePanel",
+        "storage",
+        "tabs",
+        "scripting",
+        "activeTab",
+        "contextMenus"
+    ],
+    "side_panel": {
+        "default_path": "sidepanel/index.html"
+    },
+    "icons": {
+        "16": "/icons/icon16.png",
+        "48": "/icons/icon48.png",
+        "128": "/icons/icon128.png"
+    },
+    "action": {
+        "default_title": "Open Sidebar",
+        "default_icon": {
+            "16": "/icons/icon16.png",
+            "48": "/icons/icon48.png",
+            "128": "/icons/icon128.png"
+        }
+    },
+    "background": {
+        "service_worker": "service-worker.js",
+        "type": "module"
+    },
+    "host_permissions": [],
+    "optional_host_permissions": [
+        "<all_urls>",
+        "https://openpromptdatabase.com/*",
+        "https://www.openpromptdatabase.com/*"
+    ],
+    "externally_connectable": {
+        "matches": [
+            "https://openpromptdatabase.com/*",
+            "https://www.openpromptdatabase.com/*"
+        ]
+    },
+    "web_accessible_resources": [
+        {
+            "resources": [
+                "icons/*",
+                "changelog.html",
+                "storage/promptStorage.js",
+                "storage/pinnedInputStorage.js",
+                "storage/learnedInputStorage.js",
+                "utils.js",
+                "llm_providers.json"
+            ],
+            "matches": [
+                "<all_urls>"
+            ]
+        }
+    ]
+}

--- a/src/manifest.firefox.json
+++ b/src/manifest.firefox.json
@@ -1,0 +1,67 @@
+{
+    "manifest_version": 3,
+    "name": "Open Prompt Manager - for AI Agents & Assistants",
+    "version": "3.0.1",
+    "description": "Open Source Prompt Manager for ChatGPT, Claude, Gemini, Grok and more.",
+    "browser_specific_settings": {
+        "gecko": {
+            "id": "open-prompt-manager@openpromptdatabase.com",
+            "strict_min_version": "128.0"
+        }
+    },
+    "permissions": [
+        "storage",
+        "tabs",
+        "scripting",
+        "activeTab",
+        "contextMenus"
+    ],
+    "sidebar_action": {
+        "default_title": "Open Sidebar",
+        "default_panel": "sidepanel/index.html",
+        "default_icon": {
+            "16": "/icons/icon16.png",
+            "48": "/icons/icon48.png",
+            "128": "/icons/icon128.png"
+        }
+    },
+    "icons": {
+        "16": "/icons/icon16.png",
+        "48": "/icons/icon48.png",
+        "128": "/icons/icon128.png"
+    },
+    "action": {
+        "default_title": "Open Sidebar",
+        "default_icon": {
+            "16": "/icons/icon16.png",
+            "48": "/icons/icon48.png",
+            "128": "/icons/icon128.png"
+        }
+    },
+    "background": {
+        "scripts": ["service-worker.js"],
+        "type": "module"
+    },
+    "host_permissions": [],
+    "optional_host_permissions": [
+        "<all_urls>",
+        "https://openpromptdatabase.com/*",
+        "https://www.openpromptdatabase.com/*"
+    ],
+    "web_accessible_resources": [
+        {
+            "resources": [
+                "icons/*",
+                "changelog.html",
+                "storage/promptStorage.js",
+                "storage/pinnedInputStorage.js",
+                "storage/learnedInputStorage.js",
+                "utils.js",
+                "llm_providers.json"
+            ],
+            "matches": [
+                "<all_urls>"
+            ]
+        }
+    ]
+}

--- a/src/opd/opd-bridge.js
+++ b/src/opd/opd-bridge.js
@@ -6,6 +6,8 @@
 const OPD_REQUEST_IMPORT = 'OPD_REQUEST_IMPORT';
 const OPD_IMPORT_RESULT = 'OPD_IMPORT_RESULT';
 
+const browserAPI = globalThis.browser ?? globalThis.chrome;
+
 window.addEventListener('message', (event) => {
   if (event.source !== window || !event.data || event.data.type !== OPD_REQUEST_IMPORT) {
     return;
@@ -14,8 +16,8 @@ window.addEventListener('message', (event) => {
   const { requestId, prompt } = event.data;
   if (!requestId || !prompt) return;
 
-  chrome.runtime.sendMessage({ type: 'OPD_IMPORT_PROMPT', prompt }, (response) => {
-    const lastError = chrome.runtime.lastError?.message;
+  browserAPI.runtime.sendMessage({ type: 'OPD_IMPORT_PROMPT', prompt }, (response) => {
+    const lastError = browserAPI.runtime.lastError?.message;
     window.postMessage(
       {
         type: OPD_IMPORT_RESULT,

--- a/src/service-worker.js
+++ b/src/service-worker.js
@@ -641,7 +641,10 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 });
 
 chrome.runtime.onInstalled.addListener(function (details) {
-  chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+  // COMMENT: Firefox uses sidebar_action instead of chrome.sidePanel
+  if (chrome.sidePanel?.setPanelBehavior) {
+    chrome.sidePanel.setPanelBehavior({ openPanelOnActionClick: true });
+  }
   console.log('onInstalled', details);
   // COMMENT: Rebuild providers map on install and update (but only open UI on first install)
   const shouldRebuild = ['install', 'update'].includes(details.reason);

--- a/tests/utils.test.js
+++ b/tests/utils.test.js
@@ -15,7 +15,7 @@ async function getExtensionId(browser) {
       const type = target.type();
       const url = target.url();
       return (type === 'service_worker' || type === 'background_page' || type === 'background_service_worker')
-        && url.startsWith('chrome-extension://');
+        && (url.startsWith('chrome-extension://') || url.startsWith('moz-extension://'));
     });
 
     if (extensionTarget) {


### PR DESCRIPTION
## Summary
- Port of [@VolodymyrUhera](https://github.com/VolodymyrUhera)’s cross-browser work in #79 onto current `main` (3.0.1).
- Chrome stays the store package: `src/manifest.json` / `manifest.chrome.json` have **no** static catalog `content_scripts` (optional hosts only).
- Firefox gets `sidebar_action`, a gecko id, and a module background script. `chrome.sidePanel` is skipped when the API is missing.

## What we did not take from #79
- Replacing `permissions.request` with `contains` when enabling publish (that cannot grant catalog access).
- Storage fallbacks that referenced an undefined `ChromeBridge`.
- Putting `openpromptdatabase.com` / localhost back in `content_scripts` (that would disable Chrome installs on update).

## Still follow-up
Firefox sidebar open from in-page onboarding is not wired the same as Chrome `sidePanel.open`. Load as a temporary add-on and open the sidebar from Firefox’s UI.

## Test plan
- [ ] `npm run build:chrome` then load unpacked `src/` in Chrome — onboarding, insert, catalog import still work
- [ ] `npm run build:firefox` then load `src/manifest.json` from `about:debugging` — sidebar opens, in-page launcher works
- [ ] `npm run build:chrome` again before any Chrome zip so `src/manifest.json` is the Chrome manifest
- [ ] Confirm Chrome zip still has empty `host_permissions` and no `content_scripts`

Closes #78
Supersedes the merge of #79 onto current main (leave #79 open for the original discussion)


Made with [Cursor](https://cursor.com)